### PR TITLE
Add Gamepad handling - xbox only

### DIFF
--- a/javascript/index.html
+++ b/javascript/index.html
@@ -112,6 +112,10 @@
           <label for="command">Command:</label>
           <select id="command"></select>
         </div>
+        <div class="input-group">
+          <label for="gamepad">Gamepads (Xbox). Hold LB to control.</label>
+          <select id="gamepad"></select>
+        </div>
         <div class="button-group">
           <button id="connect-btn" class="button-primary">Connect</button>
           <button id="execute-btn" class="button-primary">Execute</button>


### PR DESCRIPTION
Adds support to use Gamepad in the JS sample app. Xbox only supported, must press LB to process Joystick input.